### PR TITLE
Add GitHub Actions deploy pipeline for MCP server

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,60 @@
+name: Deploy MCP Server
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+      - name: Verify formatting
+        run: |
+          gofmt -l . | tee /tmp/gofmt.out
+          test ! -s /tmp/gofmt.out
+      - name: Run tests
+        run: go test ./...
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: lint-and-test
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+      - name: Build MCP server binary
+        run: go build -o mcpserver ./cmd/mcpserver
+      - name: Upload binary to server
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.MCP_SERVER_HOST }}
+          username: ${{ secrets.MCP_SERVER_USER }}
+          password: ${{ secrets.MCP_SERVER_PASSWORD }}
+          port: 22
+          source: mcpserver
+          target: /tmp/mcpserver
+      - name: Restart MCP service
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.MCP_SERVER_HOST }}
+          username: ${{ secrets.MCP_SERVER_USER }}
+          password: ${{ secrets.MCP_SERVER_PASSWORD }}
+          port: 22
+          script_stop: true
+          script: |
+            set -euo pipefail
+            sudo install -m 0755 /tmp/mcpserver /usr/local/bin/mcpserver
+            sudo systemctl restart mcpserver
+            sudo systemctl status mcpserver --no-pager

--- a/README.md
+++ b/README.md
@@ -74,3 +74,17 @@ go fmt ./...
 ```
 
 The CI workflow enforces formatting, vetting, and unit tests to keep the codebase consistent and reliable.
+
+## Deployment Pipeline
+
+A GitHub Actions workflow in `.github/workflows/deploy.yml` handles automated deployment of the MCP server once changes reach the `main` branch. The pipeline performs formatting checks, runs the Go test suite, and, on success, builds the `mcpserver` binary and ships it to the remote host before restarting the service.
+
+Before enabling deployments, create the following repository secrets so the workflow can authenticate with your target server:
+
+| Secret | Description |
+| --- | --- |
+| `MCP_SERVER_HOST` | Public hostname or IP address of the deployment target (for example `64.188.97.146`). |
+| `MCP_SERVER_USER` | SSH user with permission to deploy the service (for example `codex`). |
+| `MCP_SERVER_PASSWORD` | Password for the SSH user. |
+
+Once the secrets are configured, pushes to `main` or manual workflow dispatches will upload the freshly built binary to `/tmp/mcpserver` on the target, install it to `/usr/local/bin`, and restart the associated `systemd` service.


### PR DESCRIPTION
## Summary
- add a deployment workflow that runs formatting checks, tests, and publishes the built binary to the remote MCP host
- document the required GitHub secrets and deployment behavior in the README

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e48dd76c648333aed91d5e975edfda